### PR TITLE
Deprecate old `kprove` tool

### DIFF
--- a/kwasm
+++ b/kwasm
@@ -81,7 +81,7 @@ run_prove() {
     ! $repl       || additional_proof_args+=(--debugger)
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report $bug_report_name")
 
-    kprove --directory "$backend_dir" -I "$kwasm_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "$@"
+    kprove-legacy --directory "$backend_dir" -I "$kwasm_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "$@"
 }
 
 # Main


### PR DESCRIPTION
This PR switches `kwasm prove` over to `kprove-legacy`, in preparation for `kprovex` being renamed.