### PR TITLE
Fix `KBytes`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,10 @@ tests/%.wasm.bparse: tests/%.wasm pykwasm-poetry-install
 
 binary_parser_tests:=$(wildcard tests/binary/*.wat)
 
-test-binary-parser: $(binary_parser_tests:.wat=.wasm.bparse)
+test-binary-parser: $(binary_parser_tests:.wat=.wasm.bparse) test-kwasm-ast
+
+test-kwasm-ast: pykwasm-poetry-install
+	poetry -C pykwasm run pytest binary-parser/test_kwasm_ast.py
 
 # Analysis
 # --------

--- a/binary-parser/kwasm_ast.py
+++ b/binary-parser/kwasm_ast.py
@@ -9,7 +9,8 @@ It is a mirror of the abstract syntax in the K semantics.
 """
 
 from pyk.kast.inner import KSequence, KApply, KToken
-
+from pyk.prelude.bytes import bytesToken
+from pyk.utils import dequote_str
 ###########
 # KLabels #
 ###########
@@ -68,10 +69,7 @@ def KString(value : str):
 
 def KBytes(bs : bytes):
     # Change from python bytes repr to bytes repr in K.
-    byte_repr = '{}'.format(bs)
-    if byte_repr.startswith("b'") and byte_repr.endswith("'") :
-        byte_repr = 'b"' + byte_repr[2:-1] + '"'
-    return KToken(byte_repr, 'Bytes')
+    return bytesToken(dequote_str(str(bs))[2:-1])
 
 ###########
 # Strings #

--- a/binary-parser/kwasm_ast.py
+++ b/binary-parser/kwasm_ast.py
@@ -11,6 +11,7 @@ It is a mirror of the abstract syntax in the K semantics.
 from pyk.kast.inner import KSequence, KApply, KToken
 from pyk.prelude.bytes import bytesToken
 from pyk.utils import dequote_str
+
 ###########
 # KLabels #
 ###########

--- a/binary-parser/test_kwasm_ast.py
+++ b/binary-parser/test_kwasm_ast.py
@@ -1,0 +1,23 @@
+import pytest
+
+from kwasm_ast import KBytes
+
+KBYTES_TEST_DATA = (
+    (bytes([0x0, 0x41, 0xff]),        'b"\x00\x41\xff"'),
+    (bytes([]),                       'b""'),
+    (b'WASM',                         'b"WASM"'),
+    (b'foo\xAA\x01barbaz',            'b"foo\xAA\x01barbaz"'),
+    (b'foo\xAAbar\x01baz',            'b"foo\xAAbar\x01baz"'),
+    (b'abcdefghijklmnopqrstuvwxyz',   'b"abcdefghijklmnopqrstuvwxyz"'),
+    (0x11223344556677889900aabbccddeeff.to_bytes(length=16, byteorder='big'),
+        'b"\x11\x22\x33\x44\x55\x66\x77\x88\x99\x00\xaa\xbb\xcc\xdd\xee\xff"')
+)
+
+@pytest.mark.parametrize(('input', 'expected'), KBYTES_TEST_DATA)
+def test_kbytes(input, expected) -> None:
+    # When
+    t = KBytes(input)
+
+    # Then
+    assert t.token == expected
+    assert t.sort.name == 'Bytes'


### PR DESCRIPTION
This PR fixes the `KBytes` function in `binary-parser`, which converts Python `bytes` to K `Bytes`. The current implementation puts extra backslashes.  

```python
>>> from kwasm_ast import KBytes
>>> KBytes(bytes([0, 65, 255])).token
'b"\\x00A\\xff"'
>>> KBytes(bytes([0, 65, 255])).token == 'b"\x00\x41\xff"'
False
>>> KBytes(bytes([0x0, 0x41, 0xff])).token == 'b"\x00\x41\xff"'
False
```

After the fix:
```python
>>> from kwasm_ast import KBytes
>>> KBytes(bytes([0, 65, 255])).token == 'b"\x00A\xff"'
True
>>> KBytes(bytes([0, 65, 255])).token == 'b"\x00\x41\xff"'
True
>>> KBytes(bytes([0x0, 0x41, 0xff])).token == 'b"\x00\x41\xff"'
True
```

This solution is taken from [`avm-semantics`](https://github.com/runtimeverification/avm-semantics/blob/35a75917cad492bd37485db82345d218f9c4bd74/kavm/src/kavm/pyk_utils.py#L181).