### PR TITLE
Switch to GH Runner based dependency updater

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - update-deps
 
 jobs:
 

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - update-deps
 
 jobs:
 

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -25,4 +25,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28"                              \
             https://api.github.com/repos/runtimeverification/devops/dispatches \
             -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/wasm-semantics","version":"'${version}'"}}'
-

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,0 +1,27 @@
+name: 'Master Push'
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  release:
+    name: 'Publish Release'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: 'Update dependents'
+        env:
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+        run: |
+          set -x
+          version="${GITHUB_SHA}"
+          curl --fail                                                          \
+            -X POST                                                            \
+            -H "Accept: application/vnd.github+json"                           \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                         \
+            -H "X-GitHub-Api-Version: 2022-11-28"                              \
+            https://api.github.com/repos/runtimeverification/devops/dispatches \
+            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/wasm-semantics","version":"'${version}'"}}'
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,16 +28,5 @@ pipeline {
         }
       }
     }
-    stage('Master Release') {
-      when { branch 'master' }
-      environment { LONG_REV = """${sh(returnStdout: true, script: 'git rev-parse HEAD').trim()}""" }
-      steps {
-        build job: 'DevOps/master', propagate: false, wait: false                                                      \
-            , parameters: [ booleanParam ( name: 'UPDATE_DEPS'         , value: true                                 ) \
-                          , string       ( name: 'UPDATE_DEPS_REPO'    , value: 'runtimeverification/wasm-semantics' ) \
-                          , string       ( name: 'UPDATE_DEPS_VERSION' , value: "${env.LONG_REV}"                    ) \
-                          ]
-      }
-    }
   }
 }


### PR DESCRIPTION
This switches from using Jenkinsfile + Jenkins-based dependency updater to using a GH job on master push with the devops action for triggering updates.